### PR TITLE
Remove default value for Content-Transfer-Encoding

### DIFF
--- a/email2pb.py
+++ b/email2pb.py
@@ -45,7 +45,7 @@ body_text = ''
 for part in msg.walk():
     if part.get_content_type() == 'text/plain':
         body_part = part.get_payload()
-        if part.get('Content-Transfer-Encoding', 'base64') == 'base64':
+        if part.get('Content-Transfer-Encoding') == 'base64':
             body_part = base64.decodestring(body_part)
         part_encoding = part.get_content_charset()
         if part_encoding:


### PR DESCRIPTION
The current default value is 'base64' which makes everything without that header be decoded as base64 and crash the script. I think the oposite should be the case. I worked on this with @frdmn and he confirmed it to work.
